### PR TITLE
Redirect to docs.astronomer.io as primary domain

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: 'Astronomer Cloud (Beta)',
   tagline: 'Get Started with the Next Generation of Astronomer Cloud',
-  url: 'https://beta-docs.astronomer.io',
+  url: 'https://docs.astronomer.io',
   baseUrl: '/',
   noIndex: true,
   onBrokenLinks: 'throw',

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+https://beta-docs.astronomer.io* https://beta-docs.astronomer.io:splat 301


### PR DESCRIPTION
Sets `docs.astronomer.io` as the primary domain and introduces a redirect for any traffic coming in at `beta-docs.astronomer.io`.