### PR TITLE
Small Cleanup

### DIFF
--- a/docs/airflow-api.md
+++ b/docs/airflow-api.md
@@ -42,7 +42,7 @@ Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG"
 
 Use the following example API requests to begin automating your own Airflow actions. For more examples, see Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html).
 
-### Trigger a DAG (cURL)
+### Trigger a DAG
 
 If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint:
 
@@ -96,7 +96,7 @@ curl -v -X POST
 -H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
 ```
 
-### Get All Pools (Python)
+### Get All Pools
 
 If you want to get all existing Pools from your Deployment, you can start with a generic Python command to Airflow's `GET` endpoint:
 

--- a/docs/airflow-api.md
+++ b/docs/airflow-api.md
@@ -33,7 +33,7 @@ To retrieve your Deployment URL, open your Deployment in the Astronomer UI and c
 With the information from Step 1, you can now run `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html). For example, to retrieve a list of all DAGs in a Deployment, you can run:
 
 ```sh
-curl -X GET <base-deployment-url>/api/v1/dags -H 'Accept: application/json' -H 'Cache-Control: no-cache' -H "Authorization: Bearer <access-token>"
+curl -X GET <deployment-url>/api/v1/dags -H 'Accept: application/json' -H 'Cache-Control: no-cache' -H "Authorization: Bearer <access-token>"
 ```
 
 Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
@@ -42,23 +42,29 @@ Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG"
 
 Use the following example API requests to begin automating your own Airflow actions. For more examples, see Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html).
 
-### Trigger a DAG
+### Trigger a DAG (cURL)
 
 If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint:
 
 ```
-POST /airflow/api/v1/dags/<DAG_ID>/dag_runs
+POST /airflow/api/v1/dags/<dag-id>/dag_runs
 ```
 
 The command for your request should look like this:
 
 ```
 curl -v -X POST
-<base-deployment-url>/api/v1/dags/<dag-id>/dag_runs
--H 'Authorization: Bearer <access-token> ’
+<deployment-url>/api/v1/dags/<dag-id>/dag_runs
+-H 'Authorization: Bearer <access-token>’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’
 ```
+
+Make sure to replace the following values with your own:
+
+- `<dag-id>`
+- `<deployment-url>`
+- `<access-token>`
 
 This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the **Play** button in the main **DAGs** view of the Airflow UI.
 
@@ -84,13 +90,13 @@ Here, your request becomes:
 
 ```
 curl -v -X POST
-<base-deployment-url>/api/v1/dags/<dag-id>/dag_runs
+<deployment-url>/api/v1/dags/<dag-id>/dag_runs
 -H ‘Authorization: <access-token>’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
 ```
 
-### Get All Pools
+### Get All Pools (Python)
 
 If you want to get all existing Pools from your Deployment, you can start with a generic Python command to Airflow's `GET` endpoint:
 
@@ -104,9 +110,9 @@ Here, your request would look like this:
 python
 import requests
 token="<access-token>"
-base_url="<base-deployment-url>"
+base_url="<deployment-url>"
 resp = requests.get(
-   url=base_url + "<base-deployment-url>/api/v1/pools",
+   url=base_url + "/api/v1/pools",
    headers={"Authorization": token},
    data={}
 )

--- a/docs/airflow-api.md
+++ b/docs/airflow-api.md
@@ -24,9 +24,9 @@ Before making an Airflow API request, you need to retrieve a few key pieces of i
 - An access token.
 - A Deployment URL.
 
-To retrieve an access token, go to `cloud.astronomer.io/token` and copy the token that appears. This token is valid only for 24 hours. In this doc, we use `<access-token>` as a placeholder for this value. Replace it with your own.
+To retrieve an access token, go to `cloud.astronomer.io/token` and copy the token that appears. This token is valid only for 24 hours.
 
-To retrieve your Deployment URL, open your Deployment in the Astronomer UI and click **Open Airflow**. The base URL for the Airflow UI is your base Deployment URL. It includes your organization's URL, followed by a short Deployment ID (For example: `https://mycompany.astronomer.run/dhbhijp0`). In this doc, we use `<base-deployment-url>` as a placeholder for this value. Replace it with your own.
+To retrieve your Deployment URL, open your Deployment in the Astronomer UI and click **Open Airflow**. The URL where you are now accessing the Airflow UI is your Deployment URL. It includes the name of your Organization and a short Deployment ID. For example: `https://mycompany.astronomer.run/dhbhijp0`.
 
 ## Step 2: Make an Airflow API Request
 

--- a/docs/airflow-api.md
+++ b/docs/airflow-api.md
@@ -24,9 +24,9 @@ Before making an Airflow API request, you need to retrieve a few key pieces of i
 - An access token.
 - A Deployment URL.
 
-To retrieve an access token, go to `cloud.astronomer.io/token` and copy the token that appears. This token is valid only for 24 hours.
+To retrieve an access token, go to `cloud.astronomer.io/token` and copy the token that appears. This token is valid only for 24 hours. In this doc, we use `<access-token>` as a placeholder for this value. Replace it with your own.
 
-To retrieve your Deployment URL, open your Deployment in the Astronomer UI and click **Open Airflow**. The base URL for the Airflow UI is your base Deployment URL. It includes your organization's URL, followed by a short Deployment ID (For example: `https://mycompany.astronomer.run/dhbhijp0`).
+To retrieve your Deployment URL, open your Deployment in the Astronomer UI and click **Open Airflow**. The base URL for the Airflow UI is your base Deployment URL. It includes your organization's URL, followed by a short Deployment ID (For example: `https://mycompany.astronomer.run/dhbhijp0`). In this doc, we use `<base-deployment-url>` as a placeholder for this value. Replace it with your own.
 
 ## Step 2: Make an Airflow API Request
 
@@ -55,7 +55,7 @@ The command for your request should look like this:
 ```
 curl -v -X POST
 <base-deployment-url>/api/v1/dags/<dag-id>/dag_runs
--H 'Authorization: Bearer <api-key> ’
+-H 'Authorization: Bearer <access-token> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’
 ```
@@ -85,7 +85,7 @@ Here, your request becomes:
 ```
 curl -v -X POST
 <base-deployment-url>/api/v1/dags/<dag-id>/dag_runs
--H ‘Authorization: <api-key>’
+-H ‘Authorization: <access-token>’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
 ```
@@ -103,7 +103,7 @@ Here, your request would look like this:
 ```python
 python
 import requests
-token="<api-key>"
+token="<access-token>"
 base_url="<base-deployment-url>"
 resp = requests.get(
    url=base_url + "<base-deployment-url>/api/v1/pools",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,11 +7,11 @@ slug: /
 
 ## Overview
 
-Welcome to Astronomer Cloud. We're thrilled to have you onboard as 'Build Partners' as we launch the next generation of our product. We expect our teams to be in close communication throughout the program, and this page will serve as a home for official product documentation.
+Welcome to Astronomer Cloud. We're thrilled to have you onboard as we launch the next generation of our product. This page will serve as a home for official product documentation for Astronomer Cloud.
 
 To start, Astronomer Cloud includes a game-changing deployment model that offers the self-service convenience of a fully managed Cloud service (the “control plane”) while respecting the need to keep data private, secure, and within corporate boundaries (the “data plane”).
 
-This model optimizes for security whilst relieving your team of operational overhead. As we look beyond initial release and build a robust set of differentiating features, we very much look forward to hearing your feedback.
+This model optimizes for security whilst relieving your team of operational overhead. We have a strong foundation available today and look forward to hearing your feedback as we build a robust set of differentiating features.
 
 ## Features
 
@@ -21,7 +21,6 @@ Astronomer Cloud's architecture enables a few key features, available today:
 - Support for a multi-tenant data plane hosted in your organization's network on AWS (`us-east-1` and `us-west-2`)
 - Worker auto-scaling, powered by Airflow's Celery Executor + KEDA
 - Astronomer Runtime, a new collection of Docker images set to provide a differentiated Airflow experience. Astronomer Runtime currently supports Airflow 2.1.1. Support for Airflow 2.2 coming soon
-- Real-time, in-app chat support powered by Intercom
 
 The following diagram outlines how the control plane, data plane, and users are connected to enable these features:
 
@@ -35,10 +34,8 @@ For more information on each of these features, explore the documentation links 
 
 Our team will reach out to yours to schedule an onboarding session for the initial install. From there, we recommend reading through the following docs:
 
-- [Configure your Deployment](configure-deployment)
 - [Install the Astronomer CLI](install-cli)
-- [Deploy Code](deploy-code)
+- [Develop Locally](develop-locally)
+- [Configure your Deployment](configure-deployment)
 
-If you have a feature request or find a bug to report, reach out to us in the in-app chat modal or drop us a note in our shared Slack Channel. You'll be connected directly with our Product team.
-
-Once again, we sincerely appreciate your participation and can't wait to form an even deeper partnership with your team. Let's do this thing!
+If you have a feature request or find a bug to report, reach out to us at support@astronomer.io or drop our team a note in our shared Slack Channel. You'll be connected directly with our Product team.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,7 +24,7 @@ If you have any questions or a bug to report, don't hesitate to reach out to us 
 
 :::danger
 
-This release introduces a breaking change to code deploys via the Astronomer CLI. Starting on September 28, you must upgrade to v1.0.0 of the CLI to deploy code to Astronomer. [CI/CD processes](ci-cd) enabled by Deployment API Keys will continue to work and will not be affected. For more information, read the [CLI release notes](cli-release-notes).
+This release introduces a breaking change to code deploys via the Astronomer CLI. Starting on September 28, you must upgrade to v1.0.0 of the CLI to deploy code to Astronomer. [CI/CD processes](ci-cd) enabled by Deployment API keys will continue to work and will not be affected. For more information, read the [CLI release notes](cli-release-notes).
 
 :::
 

--- a/docs/runtime-release-notes.md
+++ b/docs/runtime-release-notes.md
@@ -37,12 +37,12 @@ If you have any questions or a bug to report, don't hesitate to reach out to us 
 ### Minor improvements
 
 - Upgraded the default Python version to `3.9.6`
-- Added a link to Astronomer Cloud documentation in the Runtime Airflow UI
+- Added a link to Astronomer Cloud documentation in the Airflow UI
 
 ### Bug fixes
 
-- Removed nonfunctional security and user profile elements from the Runtime Airflow UI
-- The Runtime Airflow UI now shows the correct version of Runtime in the footer
+- Removed nonfunctional security and user profile elements from the Airflow UI
+- The Airflow UI now shows the correct version of Astronomer Runtime in the footer
 
 ## Astronomer Runtime 3.0.0
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   favicon: 'img/favicon.svg',
   noIndex: true,
   organizationName: 'astronomer', // Usually your GitHub org/user name.
-  projectName: 'beta-docs', // Usually your repo name.
+  projectName: 'cloud-docs', // Usually your repo name.
   themeConfig: {
     algolia: {
       apiKey: '1821ae84c278294f722376cb52b520c0',
@@ -52,7 +52,7 @@ module.exports = {
           // The baseUrl will be automatically prepended to this value.
           to: 'https://www.astronomer.io/docs',
           // The string to be shown.
-          label: 'Return to Main Docs ↗',
+          label: 'Go to Main Docs ↗',
           // Left or right side of the navbar.
           position: 'right', // or 'right'
         },
@@ -61,7 +61,7 @@ module.exports = {
     footer: {
       links: [
         {
-          title: 'Docs (Beta)',
+          title: 'Astronomer Cloud Docs',
           items: [
             {
               label: 'Overview',
@@ -113,8 +113,8 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: ({versionDocsDirPath, docPath}) =>
-    `https://github.com/astronomer/cloud-docs/blob/main/docs/${docPath}`,
+          editUrl: ({ versionDocsDirPath, docPath }) =>
+            `https://github.com/astronomer/cloud-docs/blob/main/docs/${docPath}`,
           editLocalizedFiles: true,
           routeBasePath: '/',
           admonitions: {


### PR DESCRIPTION
Hey @jwitz - was reading through our docs today and found a few minor inconsistencies that I wanted to address. Includes:

- Rename the Cloud docs footer to remove the use of "Beta"
- Re-word the "Overview" doc to de-beta-fi it further
- Remove use of `<api-key>` in Airflow API docs and replace with `<access-token>`
- Replace `Runtime Airflow UI` with `Airflow UI`