### PR TITLE
Runtime 4.0.4 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,9 +10,9 @@ Astronomer is committed to continuous development of Astronomer Cloud. As you gr
 
 If you have any questions or a bug to report, don't hesitate to reach out to us via Slack or Intercom. We're here to help.
 
-**Latest Runtime Version**: 4.0.3 ([Release notes](runtime-release-notes))
+**Latest Runtime Version**: 4.0.4 ([Release notes](runtime-release-notes))
 
-**Latest CLI Version**: 1.0.2 ([Release notes](cli-release-notes))
+**Latest CLI Version**: 1.0.3 ([Release notes](cli-release-notes))
 
 ## November 19, 2021
 

--- a/docs/runtime-release-notes.md
+++ b/docs/runtime-release-notes.md
@@ -10,6 +10,15 @@ Astronomer Runtime is a Docker image built and published by Astronomer that exte
 
 For instructions on how to upgrade, read [Upgrade Astronomer Runtime](upgrade-runtime). For general product release notes, go to [Astronomer Cloud Release Notes](release-notes). If you have any questions or a bug to report, don't hesitate to reach out to us via Slack or [support@astronomer.io](mailto:support@astronomer.io).
 
+## Astronomer Runtime 4.0.4
+
+- Release date: November 19, 2021
+- Airflow version: 2.2.2
+
+### Bug Fixes
+
+- Fixed an issue where DAG run and task instance records didn't show up as expected in the Airflow UI
+
 ## Astronomer Runtime 4.0.3
 
 - Release date: November 15, 2021

--- a/docs/runtime-release-notes.md
+++ b/docs/runtime-release-notes.md
@@ -28,6 +28,10 @@ For instructions on how to upgrade, read [Upgrade Astronomer Runtime](upgrade-ru
 
 - Added support for [Airflow 2.2.2](https://airflow.apache.org/docs/apache-airflow/stable/changelog.html#airflow-2-2-2-2021-11-15), which includes a series of bug fixes for timetables, DAG scheduling, and database migrations. Most notably, it resolves an issue where some DAG runs would be missing in the Airflow UI if `catchup=True` was set.
 
+### Bug Fixes
+
+- Fixed an issue where the Astronomer-themed Airflow UI was not present in local development
+
 ## Astronomer Runtime 4.0.2
 
 - Release date: October 29, 2021

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,4 @@
 export const siteVariables = {
   cliVersion: '1.0.3',
-  runtimeVersion: '4.0.3'
+  runtimeVersion: '4.0.4'
 };


### PR DESCRIPTION
Couple things here:

- Added Runtime 4.0.4 to release notes
- Updated release notes file with latest Runtime + CLI (CLI was outdated)

@jwitz Should we have those "latest" CLI/Runtime versions in release notes be called from the Env Var you set? Realizing we're still adding those manually